### PR TITLE
Cache Indexer Job fix

### DIFF
--- a/dataset-registry/src/main/scala/org/sunbird/obsrv/streaming/BaseDatasetProcessFunction.scala
+++ b/dataset-registry/src/main/scala/org/sunbird/obsrv/streaming/BaseDatasetProcessFunction.scala
@@ -28,11 +28,11 @@ trait SystemEventHandler {
   }
 
   private def getTime(timespans: Map[String, AnyRef], producer: Producer): Option[Long] = {
-    timespans.get(producer.toString).map(f => f.asInstanceOf[Long])
+    timespans.get(producer.toString).map(f => f.asInstanceOf[Number].longValue())
   }
 
   private def getStat(obsrvMeta: Map[String, AnyRef], stat: Stats): Option[Long] = {
-    obsrvMeta.get(stat.toString).map(f => f.asInstanceOf[Long])
+    obsrvMeta.get(stat.toString).map(f => f.asInstanceOf[Number].longValue())
   }
 
   def getError(error: ErrorConstants.Error, producer: Producer, functionalError: FunctionalError): Option[ErrorLog] = {

--- a/pipeline/cache-indexer/pom.xml
+++ b/pipeline/cache-indexer/pom.xml
@@ -37,23 +37,11 @@
             <groupId>org.sunbird.obsrv</groupId>
             <artifactId>dataset-registry</artifactId>
             <version>1.0.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka-clients</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-native_${scala.maj.version}</artifactId>
             <version>4.0.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
1. Removed unnecessary dependency files.  
2. Resolved the class cast exception from `int` to `long`.
3. Excluding the "obsrv_meta" information and storing the remaining information in the cache 